### PR TITLE
feat: 리뷰 삭제 기능 추가 (작성자 권한 확인 포함)

### DIFF
--- a/BE/movie-api/app/routers/reviews.py
+++ b/BE/movie-api/app/routers/reviews.py
@@ -50,3 +50,44 @@ def list_movie_reviews(
                                   .order_by(Review.created_at.desc())\
                                   .all()    # 영화 ID로 리뷰 조회
     return [make_review_out(r, r.user.user_id) for r in db_reviews] # ReviewOut 리스트로 변환하여 반환
+
+#영화 리뷰 삭제
+@router.delete( 
+    "/movies/{movie_id}/reviews/{review_id}",   # 영화 ID와 리뷰 ID를 URL 경로로 받음
+    response_model=None,    # 응답 모델 없음 (204 No Content)
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="영화 리뷰 삭제"    # 엔드포인트 요약
+)
+def delete_review( 
+    movie_id: int = Path(..., description="영화 ID"),   # URL 경로에서 영화 ID를 받음
+    review_id: int = Path(..., description="삭제할 리뷰의 ID"), # URL 경로에서 리뷰 ID를 받음
+    user_id: str = Query(..., alias="user_id", description="본인 로그인 ID"),   # 쿼리 파라미터로 user_id를 받음 (alias 사용)
+    db: Session = Depends(get_db)   # 데이터베이스 세션 의존성
+):
+    """
+    지정된 영화(movie_id)의 특정 리뷰(review_id)를, 
+    로그인 ID(user_id)와 매칭되는 작성자만 삭제할 수 있습니다.
+    """
+    # 1) 작성자 확인을 위해 User 조회 없으면 오류메시지
+    user = db.query(User).filter(User.user_id == user_id).first()   # user_id로 사용자 조회
+    if not user:    # 사용자 존재 여부 확인
+        raise HTTPException(status_code=404, detail="해당 user_id를 가진 사용자가 없습니다.")   # 사용자 없으면 404 에러
+
+    # 2) 리뷰 조회 없으면 오류메시지
+    # movie_id와 review_id로 리뷰를 조회
+    review = db.query(Review).filter(
+        Review.id == review_id, # 리뷰 ID로 필터링
+        Review.movie_id == movie_id # 영화 ID로 필터링
+    ).first()   # 리뷰 조회
+    if not review:  # 리뷰 존재 여부 확인
+        raise HTTPException(status_code=404, detail="삭제할 리뷰를 찾을 수 없습니다.")  # 리뷰 없으면 404 에러
+
+    # 3) 권한 확인: 본인 리뷰만 삭제 가능
+    if review.user_id != user.id:   # 리뷰 작성자 ID와 로그인 사용자 ID 비교
+        raise HTTPException(status_code=403, detail="본인 리뷰만 삭제할 수 있습니다.")  # 본인 리뷰가 아니면 403 에러
+
+    # 4) 리뷰 삭제
+    db.delete(review)   # 리뷰 삭제
+    db.commit()   # 데이터베이스에 커밋하여 변경사항 반영
+    # 204 No Content 를 반환
+    return


### PR DESCRIPTION
- DELETE /movies/{movie_id}/reviews/{review_id} 엔드포인트 추가
- user_id를 통해 로그인 사용자 확인 후, 본인 리뷰만 삭제 가능하도록 구현
- 존재하지 않는 사용자 또는 리뷰에 대해 404 에러 반환
- 작성자가 아닐 경우 403 에러 반환
- 성공 시 204 No Content 응답